### PR TITLE
Fix crash on macro calls with string arguments

### DIFF
--- a/nice65/app.py
+++ b/nice65/app.py
@@ -121,7 +121,7 @@ def main():
 
         comment: INDENT* ";" SENTENCE?
 
-        ?operand: REGISTER | (/#/? /[<>]/? expr)
+        ?operand: REGISTER | STRING | (/#/? /[<>]/? expr)
         ?expr: LITERAL (OP expr)?
             | /\(/ expr /\)/ -> expr
 
@@ -132,6 +132,7 @@ def main():
         LABEL: IDENT | "@" /[a-zA-Z0-9_]+/
         IDENT: /[a-zA-Z_][a-zA-Z0-9_]*/
         LABEL_REL: /:[\+\-]+/
+        STRING: /"[^"]*"/
         OP: "+" | "-" | "*" | "/" | "|" | "^" | "&" | ","
         INDENT: /[ ]+/
     """


### PR DESCRIPTION
## Summary

- nice65 crashes with `UnexpectedCharacters` when encountering macro invocations that have double-quoted string arguments (e.g. `HiAscii "BY DAN & KATHE"`)
- Root cause: the grammar's `operand` rule only accepts registers and numeric/label expressions — no string literals
- Fix: add a `STRING` terminal (`/"[^"]*"/`) and accept it as a valid alternative in the `operand` rule

## Reproduction

```asm
        HiAscii "BY DAN & KATHE"
```

Before the fix:
```
lark.exceptions.UnexpectedCharacters: No terminal matches '"' in the current parser context
```

After the fix the line is parsed and formatted correctly.

## Test plan

- [x] Verified the reproducer (`HiAscii "BY DAN & KATHE"`) now parses and formats correctly
- [x] Verified multiple string args work (`MyMacro "arg1", "arg2"`)
- [x] Verified `samples/example.s` output matches `samples/clean.s` exactly
- [x] Verified `samples/example2.s -l` output matches `samples/clean2.s` exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)