### PR TITLE
Add -C/--comment-column for inline comment alignment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 test:
 	python -m nice65 ./samples/example.s | diff - ./samples/clean.s
 	python -m nice65 ./samples/example2.s -l | diff - ./samples/clean2.s
+	python -m nice65 ./samples/example3.s -C 41 | diff - ./samples/clean3.s
 
 .PHONY: build
 build:

--- a/nice65/app.py
+++ b/nice65/app.py
@@ -89,6 +89,13 @@ def main():
         action="store_true",
     )
     parser.add_argument(
+        "-C",
+        "--comment-column",
+        help="Column to align inline comments to",
+        type=int,
+        default=24,
+    )
+    parser.add_argument(
         "-v",
         "--version",
         help="Show version",
@@ -115,8 +122,8 @@ def main():
         asm_statement: INSTR (_WS+ operand ("," operand)?)?
         macro_start: ".macro" IDENT (IDENT ("," IDENT)*)?
         macro_end: ".endmacro"
-        control_command: "." IDENT (_WS+ /[^\n]+/)?
-        constant_def: LABEL /=|:=/ /[^\n]+/
+        control_command: "." IDENT (_WS+ /[^;\n]+/)?
+        constant_def: LABEL /=|:=/ /[^;\n]+/
         numeric_var: IDENT control_command
 
         comment: INDENT* ";" SENTENCE?
@@ -146,7 +153,7 @@ def main():
                 if fnmatch.fnmatch(file, args.pattern):
                     path = os.path.join(root, file)
                     print("Fixing", path, file=sys.stderr)
-                    fix(grammar, path, None, True, args.colonless_labels, args.lowercase_mnemonics)
+                    fix(grammar, path, None, True, args.colonless_labels, args.lowercase_mnemonics, args.comment_column)
     else:
         fix(
             grammar,
@@ -155,6 +162,7 @@ def main():
             args.modify_in_place,
             args.colonless_labels,
             args.lowercase_mnemonics,
+            args.comment_column,
         )
 
 
@@ -164,7 +172,7 @@ class Version(Action):
         parser.exit()
 
 
-def fix(grammar, infile, outfile, modify_in_place, colonless_labels, lowercase_mnemonics):
+def fix(grammar, infile, outfile, modify_in_place, colonless_labels, lowercase_mnemonics, comment_column=24):
     if infile == "-":
         content = sys.stdin.read()
     else:
@@ -197,7 +205,7 @@ def fix(grammar, infile, outfile, modify_in_place, colonless_labels, lowercase_m
                     s_len = len(string)
                     if '\n' in string:
                         s_len = s_len - string.rfind('\n') - 1
-                    padding = (24 - s_len) if i > 0 else 0
+                    padding = max(1, comment_column - 1 - s_len) if i > 0 else 0
                     string += " " * padding + ("; " + sentence).strip()
                 else:
                     sentence = next(iter([x for x in child.children if x.type == "SENTENCE"]), "").strip()
@@ -236,7 +244,7 @@ def fix(grammar, infile, outfile, modify_in_place, colonless_labels, lowercase_m
                         + "."
                         + name.lower()
                         + " "
-                        + " ".join(statement.children[1:])
+                        + " ".join(x.strip() for x in statement.children[1:])
                     )
                 elif statement.data == "macro_start":
                     name = statement.children[0].strip()

--- a/samples/clean3.s
+++ b/samples/clean3.s
@@ -1,0 +1,29 @@
+; Test: -C flag aligns inline comments on various line types
+;
+; Mnemonics
+fill:
+        LDA #$a0                        ; PETSCII space
+        LDX #$fd                        ; counter
+        STA $1dff, X                    ; first page
+        DEX
+        BNE fill                        ; loop
+
+; Control commands: .byte
+        .byte $a9                       ; LDA immediate
+        .byte $1d                       ; value
+        .byte $60                       ; RTS
+
+; Control commands: .org
+        .org $2000                      ; relocated base
+
+; Constant definitions
+my_var = $15                            ; player color
+long_variable_name = $1234              ; a longer name
+x = $00                                 ; short
+
+; Standalone comments should not be affected
+        ; indented standalone
+; col-1 standalone
+
+; Tail comment on label+instruction
+foo:    RTS                             ; done

--- a/samples/example3.s
+++ b/samples/example3.s
@@ -1,0 +1,29 @@
+; Test: -C flag aligns inline comments on various line types
+;
+; Mnemonics
+fill:
+   lda #$a0 ; PETSCII space
+   ldx #$fd       ; counter
+   sta $1dff , x ;first page
+   dex
+   bne fill ; loop
+
+; Control commands: .byte
+  .byte $a9       ; LDA immediate
+ .byte $1d ; value
+   .byte $60                ; RTS
+
+; Control commands: .org
+  .org $2000         ; relocated base
+
+; Constant definitions
+my_var = $15 ; player color
+long_variable_name = $1234       ; a longer name
+x = $00   ; short
+
+; Standalone comments should not be affected
+   ; indented standalone
+; col-1 standalone
+
+; Tail comment on label+instruction
+foo:   rts ; done


### PR DESCRIPTION
## Summary
- Adds `-C`/`--comment-column` flag to control where inline (tail) comments are aligned (default: 24 for backward compatibility)
- Fixes grammar so inline comments on `constant_def` and `control_command` lines are parsed separately and aligned like all other inline comments
- Guarantees at least one space between code and comment even when the code exceeds the target column

## Example

```
# Before (hardcoded column 24, equate comments not aligned):
human_color = $15            ; color the human is playing
scoreL_stack = $23            ; score stack low bytes

# After with -C 41:
human_color = $15                       ; color the human is playing
scoreL_stack = $23                      ; score stack low bytes
        lda #$a0                        ; PETSCII space character
```

## Test plan
- [ ] Verify default behavior unchanged (column 24)
- [ ] Verify `-C 41` aligns all inline comments at column 41
- [ ] Verify comments on `.byte`, `.word`, `.org` and `=` lines are aligned
- [ ] Verify at least 1 space of padding when code exceeds target column

🤖 Generated with [Claude Code](https://claude.com/claude-code)